### PR TITLE
Add permissions needed to run generate_prototype.py

### DIFF
--- a/ApplicationServerDeployment/template/DeployStackPolicy.json
+++ b/ApplicationServerDeployment/template/DeployStackPolicy.json
@@ -61,9 +61,17 @@
                 "iotwireless:GetDestination",
                 "iotwireless:DeleteDestination",
                 "iotwireless:CreateDestination",
-                "iotwireless:UpdateDestination"
+                "iotwireless:UpdateDestination",
+                "iotwireless:CreateDeviceProfile",
+                "iotwireless:GetDeviceProfile",
+                "iotwireless:CreateWirelessDevice",
+                "iotwireless:GetWirelessDevice"
             ],
-            "Resource": "arn:aws:iotwireless:*:<account_ID>:Destination/*"
+            "Resource": [
+                "arn:aws:iotwireless:*:<account_ID>:Destination/*",
+                "arn:aws:iotwireless:*:<account_ID>:DeviceProfile/*",
+                "arn:aws:iotwireless:*:<account_ID>:WirelessDevice/*"
+            ]
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
*Issue #, if available:*
Template policy does not provide permissions needed to run generate_prototype.py

*Description of changes:*
Add necessary policies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
