### PR TITLE
Enable CloudFront distribution to call api gateway from path /api

### DIFF
--- a/ApplicationServerDeployment/template/SidewalkSampleApplicationStack.yaml
+++ b/ApplicationServerDeployment/template/SidewalkSampleApplicationStack.yaml
@@ -835,6 +835,7 @@ Resources:
     Type: AWS::CloudFront::Distribution
     DependsOn:
       - SidewalkWebAppBucket
+      - SidewalkApiGateway
     Properties:
       DistributionConfig:
         DefaultCacheBehavior:
@@ -859,6 +860,53 @@ Resources:
                   - ''
                   - - origin-access-identity/cloudfront/
                     - Ref: CloudFrontOriginAccessIdentity
+          - DomainName:
+              Fn::Join:
+                - '.'
+                - - !Ref SidewalkApiGateway
+                  - "execute-api"
+                  - Fn::Sub: ${AWS::Region}
+                  - "amazonaws.com"
+            Id:
+              Fn::Sub: ${AWS::StackName}-root-Api-Gw
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginReadTimeout: 20
+            OriginPath: /dev
+        OriginGroups:
+          Items:
+            - FailoverCriteria:
+                StatusCodes:
+                  Items:
+                    - 400
+                  Quantity: 1
+              Id:
+                Bucket and apiGw
+              Members:
+                Items:
+                  - OriginId:
+                      Fn::Sub: ${AWS::StackName}-root-Api-Gw
+                  - OriginId:
+                      Fn::Sub: ${AWS::StackName}-root
+                Quantity: 2
+          Quantity: 1
+        CacheBehaviors:
+          -
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+              - PUT
+              - PATCH
+              - POST
+              - DELETE
+            PathPattern: /api/*
+            TargetOriginId:
+              Fn::Sub: ${AWS::StackName}-root-Api-Gw
+            ViewerProtocolPolicy:
+              redirect-to-https
+            CachePolicyId:
+              4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Caching disabled
         PriceClass: PriceClass_All
 
   # OriginAccessIdentity to allow communication with 3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enables api gateway to be directly called from cloud front by adding /api/ to path. Currently we are replacing part of website code with api gateway path which is a bit hacky

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
