### PR TITLE
Measurements now use milliseconds as timestamp and are sorted. Reduces capacity of tables to 2.

### DIFF
--- a/ApplicationServerDeployment/lambda/database/measurements_handler.py
+++ b/ApplicationServerDeployment/lambda/database/measurements_handler.py
@@ -63,7 +63,7 @@ class MeasurementsHandler:
         :return:             Updated Measurement object.
         """
         try:
-            timestamp = int(time.time())
+            timestamp = int(time.time_ns() / 1000000)
             ttl = self._get_dynamodb_item_time_to_live(timestamp)
             self._table.put_item(
                 Item={
@@ -88,4 +88,4 @@ class MeasurementsHandler:
     # -----------------
     @staticmethod
     def _get_dynamodb_item_time_to_live(timestamp: int) -> int:
-        return timestamp + 3600
+        return timestamp + 3600 * 1000

--- a/ApplicationServerDeployment/template/SidewalkSampleApplicationStack.yaml
+++ b/ApplicationServerDeployment/template/SidewalkSampleApplicationStack.yaml
@@ -94,8 +94,8 @@ Resources:
         AttributeName: time_to_live
         Enabled: true
       ProvisionedThroughput:
-        ReadCapacityUnits: 10
-        WriteCapacityUnits: 10
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
       TableName: SidewalkDevices
 
   # Table for storing sensor measurements
@@ -117,17 +117,19 @@ Resources:
           KeySchema:
             - AttributeName: wireless_device_id
               KeyType: HASH
+            - AttributeName: timestamp
+              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:
-            ReadCapacityUnits: 10
-            WriteCapacityUnits: 10
+            ReadCapacityUnits: 2
+            WriteCapacityUnits: 2
       TimeToLiveSpecification:
         AttributeName: time_to_live
         Enabled: true
       ProvisionedThroughput:
-        ReadCapacityUnits: 10
-        WriteCapacityUnits: 10
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
 
 
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Measurements now use milliseconds as timestamp and are sorted. Reduces capacity of tables to 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
